### PR TITLE
feat: make api_url and api_key configurable via web setup page

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ const char* api_url = "http://192\.168\.1\.5:8080/v1/";
 
 Please make sure to escape dots (.) in the url string like in the example above.
 
+### LocalAI endpoint & key
+
+The LocalAI API URL and key can be changed at runtime, the same way as the WiFi:
+
+- Open the **LocalAI setup page** at `http://<device-ip>:8081`.
+- Enter the API URL and key and press **Save**. The values are stored in flash and applied immediately, so a reboot is not required.
+
+The values in `config.h` (`api_url` / `api_key`) only act as initial defaults.
+
 ## Required Libraries
 
 To compile the program you'll need to install the following libraries in the Arduino IDE:

--- a/TamAIgotchi/TamAIgotchi.ino
+++ b/TamAIgotchi/TamAIgotchi.ino
@@ -2,6 +2,8 @@
 #include <Adafruit_GFX.h>
 #include <Adafruit_SSD1306.h>
 #include <WiFi.h>
+#include <WebServer.h>
+#include <EEPROM.h>
 #include "ESP_I2S.h"
 #include <OpenAI.h>
 #include "config.h"
@@ -9,9 +11,37 @@
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, -1);
 I2SClass i2s;
 
-OpenAI openai(api_key, api_url);
+// LocalAI endpoint + key are configurable at runtime through a small web
+// setup page owned by this sketch. The values are persisted in flash (NVS)
+// so they survive reboots. The constants in config.h only provide the
+// initial defaults.
+//
+// Storage layout:
+//   0  : LOCALAI_URL  (60 bytes)
+//   60 : LOCALAI_KEY  (60 bytes)
+#define LOCALAI_URL_MAX  60
+#define LOCALAI_KEY_MAX  60
+#define LOCALAI_URL_ADDR 0
+#define LOCALAI_KEY_ADDR 60
+
+WebServer localaiServer(LOCALAI_SETUP_PORT);
+String localaiUrl = api_url;
+String localaiKey = api_key;
+
+// Rebuild the OpenAI client from the currently stored api_url / api_key.
+// The LocalAI-ESP32 library keeps the endpoint and key for the lifetime of
+// the object, so a new instance is created every time the settings change.
+OpenAI openai(localaiKey.c_str(), localaiUrl.c_str());
 OpenAI_ChatCompletion chat(openai);
 OpenAI_AudioTranscription audio(openai);
+
+void applyLocalAISettings() {
+  // "chat" and "audio" hold a reference to "openai", so reassigning the
+  // base object is enough for them to pick up the new endpoint + key.
+  openai = OpenAI(localaiKey.c_str(), localaiUrl.c_str());
+  Serial.print("LocalAI endpoint: ");
+  Serial.println(localaiUrl);
+}
 
 uint32_t lastButtonState = HIGH;
 uint32_t lastDebounce = 0;
@@ -25,6 +55,90 @@ void combinedOutput(int x, int y, char* line, bool clrscr) {
   display.setCursor(x, y);
   display.println(line);
   display.display();
+}
+
+// Read the LocalAI settings from flash and fall back to the defaults
+// from config.h if nothing has been saved yet.
+void loadLocalAISettings() {
+  EEPROM.begin(4096);
+  char buf[LOCALAI_URL_MAX + 1];
+  for (int i = 0; i < LOCALAI_URL_MAX; i++) {
+    char c = (char)EEPROM.read(LOCALAI_URL_ADDR + i);
+    if (c == '\0') break;
+    buf[i] = c;
+  }
+  buf[LOCALAI_URL_MAX] = '\0';
+  if (buf[0] != '\0') localaiUrl = String(buf);
+
+  char kbuf[LOCALAI_KEY_MAX + 1];
+  for (int i = 0; i < LOCALAI_KEY_MAX; i++) {
+    char c = (char)EEPROM.read(LOCALAI_KEY_ADDR + i);
+    if (c == '\0') break;
+    kbuf[i] = c;
+  }
+  kbuf[LOCALAI_KEY_MAX] = '\0';
+  if (kbuf[0] != '\0') localaiKey = String(kbuf);
+  EEPROM.end();
+
+  applyLocalAISettings();
+}
+
+// Persist the LocalAI settings into flash.
+void saveLocalAISettings() {
+  EEPROM.begin(4096);
+  for (int i = 0; i < LOCALAI_URL_MAX; i++) {
+    EEPROM.write(LOCALAI_URL_ADDR + i, localaiUrl[i]);
+  }
+  for (int i = 0; i < LOCALAI_KEY_MAX; i++) {
+    EEPROM.write(LOCALAI_KEY_ADDR + i, localaiKey[i]);
+  }
+  EEPROM.commit();
+  EEPROM.end();
+}
+
+// ---- LocalAI setup web page (http://<device-ip>:8081) -------------------
+
+void handleLocalAIStatus() {
+  String body = F("{\"url\":\"") + localaiUrl + F("\",\"keySet\":") + (localaiKey.length() > 0 ? "true" : "false") + F("}");
+  localaiServer.send(200, "application/json", body);
+}
+
+void handleLocalAISave() {
+  String url = localaiServer.hasArg("url") ? localaiServer.arg("url") : String();
+  String key = localaiServer.hasArg("key") ? localaiServer.arg("key") : String();
+  if (url.length() > 0 && url.length() <= LOCALAI_URL_MAX) localaiUrl = url;
+  if (key.length() > 0 && key.length() <= LOCALAI_KEY_MAX) localaiKey = key;
+  saveLocalAISettings();
+  applyLocalAISettings();
+  Serial.println("LocalAI settings saved");
+  localaiServer.send(200, "text/plain", "OK");
+}
+
+void handleLocalAIPage() {
+  String page = F("<html><head><title>LocalAI</title></head><body>");
+  page += F("<h1>LocalAI settings</h1>");
+  page += F("<form method=\"POST\" action=\"/localai/save\">");
+  page += F("API URL: <input type=\"text\" name=\"url\" value=\"");
+  page += localaiUrl;
+  page += F("\" size=\"40\"><br>");
+  page += F("API key: <input type=\"password\" name=\"key\" value=\"");
+  page += localaiKey;
+  page += F("\" size=\"40\"><br><br>");
+  page += F("<button type=\"submit\">Save</button>");
+  page += F("</form><p>Settings are stored in flash and applied immediately.</p>");
+  page += F("</body></html>");
+  localaiServer.send(200, "text/html", page);
+}
+
+void startLocalAIServer() {
+  localaiServer.on("/localai", HTTP_GET, handleLocalAIPage);
+  localaiServer.on("/localai/save", HTTP_POST, handleLocalAISave);
+  localaiServer.on("/localai/status", HTTP_GET, handleLocalAIStatus);
+  localaiServer.begin();
+  Serial.print("LocalAI setup page: http://");
+  Serial.print(WiFi.localIP().toString());
+  Serial.print(":");
+  Serial.println(LOCALAI_SETUP_PORT);
 }
 
 String speechToText() {
@@ -96,6 +210,9 @@ void setup() {
     }
   }
 
+/* load the LocalAI endpoint + key (flash first, config.h defaults as fallback) */
+  loadLocalAISettings();
+
 /* setup i2s */  
   combinedOutput(0, 0, "Initializing I2S bus...", true);
   i2s.setPins(I2S_SCK, I2S_WS, -1, I2S_DIN);
@@ -117,9 +234,19 @@ void setup() {
 
   audio.setTemperature(0.1);
   audio.setLanguage("en");
+
+/* LocalAI setup page: reachable at http://<device-ip>:8081 */
+  startLocalAIServer();
+
+/* show the final WiFi status */
+  combinedOutput(0, 0, "WiFi connected", true);
+  combinedOutput(0, 16, WiFi.localIP().toString().c_str(), false);
 }
 
 void loop() {
+  // Keep the LocalAI setup page responsive.
+  localaiServer.handleClient();
+
   int reading = digitalRead(BUTTON_PIN);
 
   if (reading != lastButtonState) {

--- a/TamAIgotchi/TamAIgotchi.ino
+++ b/TamAIgotchi/TamAIgotchi.ino
@@ -47,7 +47,7 @@ uint32_t lastButtonState = HIGH;
 uint32_t lastDebounce = 0;
 bool buttonPushed = false;
 
-void combinedOutput(int x, int y, char* line, bool clrscr) {
+void combinedOutput(int x, int y, const char* line, bool clrscr) {
   if(clrscr) {
     display.clearDisplay();
   }
@@ -99,7 +99,7 @@ void saveLocalAISettings() {
 // ---- LocalAI setup web page (http://<device-ip>:8081) -------------------
 
 void handleLocalAIStatus() {
-  String body = F("{\"url\":\"") + localaiUrl + F("\",\"keySet\":") + (localaiKey.length() > 0 ? "true" : "false") + F("}");
+  String body = String("{\"url\":\"") + localaiUrl + F("\",\"keySet\":") + (localaiKey.length() > 0 ? "true" : "false") + F("}");
   localaiServer.send(200, "application/json", body);
 }
 

--- a/TamAIgotchi/config.h
+++ b/TamAIgotchi/config.h
@@ -2,6 +2,8 @@ const char* ssid = "SSID";
 const char* password = "PASSWORD";
 const char* api_url = "http://192\.168\.1\.5:8080/v1/";
 const char* api_key = "sk1234567890";
+// Port of the LocalAI setup web page (http://<device-ip>:8081).
+#define LOCALAI_SETUP_PORT 8081
 
 #define SCREEN_WIDTH 128 // OLED display width, in pixels
 #define SCREEN_HEIGHT 64 // OLED display height, in pixels


### PR DESCRIPTION
Separate PR for commit 14debec575551f3aed03dbed5e32ae01a2a56348 (as requested in #1).

This is a standalone version of the LocalAI endpoint/key web setup page, based on `main` and **not** dependent on the ESP-Wifi-Config changes in #1.

## What this adds

A small web setup page on port **8081** to configure the LocalAI API URL and key at runtime:

- `GET /localai` — simple HTML form
- `POST /localai/save` — persists the values
- `GET /localai/status` — JSON status

The values are stored in flash (NVS/EEPROM) at fixed offsets and applied immediately (the `OpenAI` client is rebuilt), so no reboot is required. The constants in `config.h` only act as initial defaults.

## Files changed

- `TamAIgotchi/TamAIgotchi.ino` — WebServer + flash persistence + client rebuild
- `TamAIgotchi/config.h` — add `LOCALAI_SETUP_PORT` (8081)
- `README.md` — document the new setup page

Closes the second half of the request in https://github.com/a-i-a-d/TamAIgotchi/pull/1